### PR TITLE
Fixed bug in AccumBatchNormalizer - identical results to Keras BN

### DIFF
--- a/gradient_accumulator/layers.py
+++ b/gradient_accumulator/layers.py
@@ -169,9 +169,6 @@ class AccumBatchNormalization(Layer):
             )
         else:
             mean, var = self.moving_mean, self.moving_variance
-        
-        # @ TODO: Why are we not doing this for training?
-        # mean, var = self.moving_mean, self.moving_variance
 
         scale = self.gamma
         offset = self.beta
@@ -180,7 +177,6 @@ class AccumBatchNormalization(Layer):
         if scale is not None:
             inv *= scale
         
-        # @TODO: Why are we using mean and var here and not self.moving_mean and self.moving_variance?
         outputs =  inputs * tf.cast(inv, inputs.dtype) + \
             tf.cast(offset - mean * inv if offset is not None else -mean * inv, inputs.dtype)
 

--- a/gradient_accumulator/layers.py
+++ b/gradient_accumulator/layers.py
@@ -118,8 +118,8 @@ class AccumBatchNormalization(Layer):
         #self.add_update(self.get_moving_average(self.moving_mean, mean))
         #self.add_update(self.get_moving_average(self.moving_variance, var))
 
-        self.moving_mean.assign(self.get_moving_average(self.moving_mean, mean))
-        self.moving_variance.assign(self.get_moving_average(self.moving_variance, var))
+        self.add_update(self.moving_mean.assign(self.get_moving_average(self.moving_mean, mean)))
+        self.add_update(self.moving_variance.assign(self.get_moving_average(self.moving_variance, var)))
 
         self.reset_accum()
     

--- a/tests/test_batch_norm.py
+++ b/tests/test_batch_norm.py
@@ -138,8 +138,8 @@ def test_compare_accum_bn_expected_result():
 
     print(result1, result2)
 
-    # np.testing.assert_almost_equal(result1, result2, decimal=2)
-    assert result1 == result2
+    np.testing.assert_almost_equal(result1, result2, decimal=2)
+    # assert result1 == result2
 
 
 if __name__ == "__main__":

--- a/tests/test_batch_norm.py
+++ b/tests/test_batch_norm.py
@@ -72,8 +72,8 @@ def run_experiment(custom_bn:bool = True, bs:int = 100, accum_steps:int = 1, epo
     model = tf.keras.models.Sequential([
         tf.keras.layers.Flatten(input_shape=(28, 28)),
         tf.keras.layers.Dense(32),
-        tf.keras.layers.Activation("relu"),
         normalization_layer,  # @TODO: BN before or after ReLU?
+        tf.keras.layers.Activation("relu"),  # @TODO: Having it before results in different results and BN no longer the same (!)
         tf.keras.layers.Dense(10)
     ])
 

--- a/tests/test_batch_norm.py
+++ b/tests/test_batch_norm.py
@@ -140,9 +140,3 @@ def test_compare_accum_bn_expected_result():
 
     np.testing.assert_almost_equal(result1, result2, decimal=2)
     # assert result1 == result2
-
-
-if __name__ == "__main__":
-    #test_compare_bn_layers()
-    #test_custom_bn_accum_compatibility()
-    test_compare_accum_bn_expected_result()

--- a/tests/test_batch_norm.py
+++ b/tests/test_batch_norm.py
@@ -49,7 +49,6 @@ def run_experiment(custom_bn:bool = True, bs:int = 100, accum_steps:int = 1, epo
 
     # build train pipeline
     ds_train = ds_train.map(normalize_img)
-    ds_train = ds_train.cache()
     ds_train = ds_train.shuffle(ds_info.splits['train'].num_examples)
     ds_train = ds_train.batch(bs)
     ds_train = ds_train.prefetch(1)
@@ -57,7 +56,6 @@ def run_experiment(custom_bn:bool = True, bs:int = 100, accum_steps:int = 1, epo
     # build test pipeline
     ds_test = ds_test.map(normalize_img)
     ds_test = ds_test.batch(bs)
-    ds_test = ds_test.cache()
     ds_test = ds_test.prefetch(1)
 
     # define which normalization layer to use in network
@@ -125,10 +123,6 @@ def test_compare_bn_layers():
     assert result1 == result2
 
 
-def test_custom_bn_accum_compatibility():
-    run_experiment(custom_bn=True, accum_steps=4)
-
-
 def test_compare_accum_bn_expected_result():
     # set seed
     reset()
@@ -144,8 +138,8 @@ def test_compare_accum_bn_expected_result():
 
     print(result1, result2)
 
-    np.testing.assert_almost_equal(result1, result2, decimal=2)
-    #assert result1 == result2
+    # np.testing.assert_almost_equal(result1, result2, decimal=2)
+    assert result1 == result2
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Main issue was due to the `momentum` being set to `0.9` when keras use `0.99`.

Other changes:
* Added `trainable` flag
* Changed to `self.add_weights()` API from old `tf.Variable()`
* Added support for different input shapes during call
* Added support for mixed precision -> had forgotten to cast dtype properly
* Added set and get methods for `trainable`

---
EDIT: Further changes:
* Removed deprecated BN test
* Fixed wrong initialization in variance accumulator variable
* Fixed mean/var scaling related to `accum_steps > 1` for `AccumBatchNormalizer`