### PR TITLE
Allow poorer approximation for older tf versions in model test

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -99,7 +99,6 @@ jobs:
           pytest -v tests/test_optimizer_distribute.py
           pytest -v tests/test_model_distribute.py
 
-
   tf-compability:
     needs: build
     runs-on: ${{ matrix.os }}

--- a/tests/test_expected_result.py
+++ b/tests/test_expected_result.py
@@ -106,13 +106,17 @@ def test_expected_result():
     result3 = run_experiment(bs=50, accum_steps=2, epochs=2, modeloropt="model")
 
     # results should be identical (theoretically, even in practice on CPU)
-    if tf_version <= 10:
-        assert result1 == result2
-        assert result2 == result3
-    else:
+    if tf_version <= 6:
+        # approximation poorer as enable_op_determinism() not available for tf < 2.7
+        np.testing.assert_almost_equal(result1, result2, decimal=4)
+        np.testing.assert_almost_equal(result2, result3, decimal=4)
+    elif tf_version > 10:
         # approximation worse for tf >= 2.11
         np.testing.assert_almost_equal(result1, result2, decimal=2)
         np.testing.assert_almost_equal(result2, result3, decimal=2)
+    else
+        assert result1 == result2
+        assert result2 == result3
 
 
 if __name__ == "__main__":

--- a/tests/test_expected_result.py
+++ b/tests/test_expected_result.py
@@ -114,7 +114,7 @@ def test_expected_result():
         # approximation worse for tf >= 2.11
         np.testing.assert_almost_equal(result1, result2, decimal=2)
         np.testing.assert_almost_equal(result2, result3, decimal=2)
-    else
+    else:
         assert result1 == result2
         assert result2 == result3
 

--- a/tests/test_model_expected_result.py
+++ b/tests/test_model_expected_result.py
@@ -28,10 +28,13 @@ def test_model_expected_result():
 
     # test with model wrapper instead
     result2 = run_experiment(bs=50, accum_steps=2, epochs=2, modeloropt="model")
-
+    
     # results should be identical (theoretically, even in practice on CPU)
-    if tf_version <= 10:
-        assert result1 == result2
-    else:
+    if tf_version <= 6:
+        # approximation poorer as enable_op_determinism() not available for tf < 2.7
+        np.testing.assert_almost_equal(result1, result2, decimal=4)
+    elif tf_version > 10:
         # approximation worse for tf >= 2.11
         np.testing.assert_almost_equal(result1, result2, decimal=2)
+    else:
+        assert result1 == result2


### PR DESCRIPTION
Related to issue #96. See https://github.com/andreped/GradientAccumulator/issues/96#issuecomment-1547810179.

As we are enable to guarantee that ops compute happen deterministically for `tf < 2.7`, approximation may vary for the same experiment in different sessions. Hence, we allow poorer approximation, but still quite strict to an order of 4.