### PR TITLE
Official tf 2.2-2.15 support update

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -142,3 +142,45 @@ jobs:
 
       - name: Run tests
         run: pytest -v tests/test_model_expected_result.py
+
+  tf-2.15:
+    needs: build
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os: [ubuntu-20.04]
+        python-version: ["3.9", "3.10", "3.11"]
+        tf-version: ["2.15.0"]
+
+    steps:
+      - uses: actions/checkout@v1
+      - name: Set up Python ${{ matrix.python-version }}
+        uses: actions/setup-python@v2
+        with:
+          python-version: ${{ matrix.python-version }}
+
+      - name: Install dependencies
+        run: pip install wheel setuptools flake8 pytest-cov
+
+      - name: Install tensorflow-datasets
+        run: |
+            pip install tensorflow==${{ matrix.tf-version }} "tensorflow-datasets<=4.8.2"
+            pip install "protobuf<=3.20" --force-reinstall
+
+      - name: Download artifact
+        uses: actions/download-artifact@v3
+        with:
+          name: "Python wheel"
+
+      - name: Install wheel
+        run: pip install --find-links=. gradient_accumulator-*
+        shell: bash
+      
+      - name: Debug pip deps
+        run: pip list
+
+      - name: Test library accessibility
+        run: python -c "from gradient_accumulator import GradientAccumulateModel, GradientAccumulateOptimizer"
+
+      - name: Run tests
+        run: pytest -v tests/test_model_expected_result.py

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -163,9 +163,7 @@ jobs:
         run: pip install wheel setuptools flake8 pytest-cov
 
       - name: Install tensorflow-datasets
-        run: |
-            pip install tensorflow==${{ matrix.tf-version }} "tensorflow-datasets<=4.8.2"
-            pip install "protobuf<=3.20" --force-reinstall
+        run: pip install tensorflow==${{ matrix.tf-version }} tensorflow-datasets
 
       - name: Download artifact
         uses: actions/download-artifact@v3

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -143,7 +143,7 @@ jobs:
       - name: Run tests
         run: pytest -v tests/test_model_expected_result.py
 
-  tf-2.15:
+  latest-tf-compatibility:
     needs: build
     runs-on: ${{ matrix.os }}
     strategy:

--- a/README.md
+++ b/README.md
@@ -10,8 +10,9 @@
 
 **GradientAccumulator** was developed by SINTEF Health due to the lack of an easy-to-use method for gradient accumulation in TensorFlow 2.
 
-The package is available on PyPI and is compatible with and have been tested against `TensorFlow 2.2-2.12` and `Python 3.6-3.11`, and works cross-platform (Ubuntu, Windows, macOS).
+The package is available on PyPI and is compatible with and have been tested against `TensorFlow 2.2-2.15` and `Python 3.6-3.11`, and works cross-platform (Ubuntu, Windows, macOS).
 </div>
+
 
 ## [Continuous integration](https://github.com/andreped/GradientAccumulator#continuous-integration)
 
@@ -33,6 +34,9 @@ Or from source:
 ```
 pip install git+https://github.com/andreped/GradientAccumulator
 ```
+
+**Disclaimer:** Note that different `TensorFlow` versions supports different Python versions. Therefore, be sure to check which Python versions are supported when you install a specific `TensorFlow` version. `GradientAccumulator` does not support Python `>3.11`, as `TensorFlow` has yet to add support for them.
+
 
 ## [Getting started](https://github.com/andreped/GradientAccumulator#getting-started)
 

--- a/setup.py
+++ b/setup.py
@@ -37,7 +37,6 @@ setuptools.setup(
         "Programming Language :: Python :: 3.9",
         "Programming Language :: Python :: 3.10",
         "Programming Language :: Python :: 3.11",
-        "Programming Language :: Python :: 3.12",
         "License :: OSI Approved :: MIT License",
         "Operating System :: OS Independent"
     ],


### PR DESCRIPTION
We have added an additional test to verify that tf 2.15.0 runs fine with Python 3.9-3.11.

As the test succeeded, I believe we can add official support for tf 2.2-2.15.